### PR TITLE
Use a more-reliable structured JSON response from ChatGPT

### DIFF
--- a/option_alpha_webhook.py
+++ b/option_alpha_webhook.py
@@ -33,8 +33,7 @@ except FileNotFoundError:
 if not trade_url or not no_trade_url:
     raise ValueError("Webhook URLs not properly configured in the secret file.")
     
-# OpenAI API URL
-API_URL = "https://api.openai.com/v1/completions"
+API_URL = "https://api.openai.com/v1/chat/completions"
 
 def ask_gpt(prompt):
     headers = {
@@ -43,12 +42,14 @@ def ask_gpt(prompt):
     }
     data = {
         "model": "gpt-4",
-        "prompt": prompt,
+        "messages": [{"role": "user", "content": prompt}],
         "max_tokens": 150,
     }
     response = requests.post(API_URL, headers=headers, json=data)
+    if response.status_code != 200:
+        raise Exception(f"OpenAI API request failed: {response.text}")
     result = response.json()
-    return result["choices"][0]["text"].strip()
+    return result["choices"][0]["message"]["content"].strip()
 
 def fetch_world_events():
     # First prompt to fetch world events

--- a/option_alpha_webhook.py
+++ b/option_alpha_webhook.py
@@ -94,11 +94,11 @@ def option_alpha_trigger():
         # Step 3: Determine if we should trigger the trade or no-trade webhook
         if is_trade_recommended(impact_analysis):
             # If GPT suggests stability, trigger trade URL
-            success = trigger_option_alpha(TRADE_URL)
+            success = trigger_option_alpha(trade_url)
             message = "Market conditions are stable; trading triggered." if success else "Failed to trigger trading."
         else:
             # If GPT suggests volatility, trigger no-trade URL
-            success = trigger_option_alpha(NO_TRADE_URL)
+            success = trigger_option_alpha(no_trade_url)
             message = "High volatility detected; trading paused." if success else "Failed to trigger no-trade."
 
         # Output the result message


### PR DESCRIPTION
**Background:**
As described in [my comment on Option Alpha](https://app.optionalpha.com/community/all/post/increasing-win-on-the-wifly-1dte-60-wi-2024110117442), there are some issues with the current implementation that can easily lead to false positives that trigger pausing trading incorrectly.  By requesting that ChatGPT format its responses in a structured manner (i.e. JSON), we can vastly improve the script's reliability.

**This PR:**
- Requests a structured JSON response from ChatGPT to improve reliability
- Switches to the [newer OpenAI API endpoint](https://platform.openai.com/docs/api-reference/making-requests) 
- Fixes a couple url references

**Note:**
Feel free to take this PR with a grain of salt as I've not been able to test it at all due to having issues getting the dependencies to install alongside my funky work environment's setup.  It won't hurt my feelings if you need to make corrections and/or additional updates to resolve any issues I missed due to not being able to verify things yet.